### PR TITLE
Update and fix newlib version test

### DIFF
--- a/heap_useNewlib_NXP.c
+++ b/heap_useNewlib_NXP.c
@@ -64,8 +64,8 @@
 #include <stddef.h>
 
 #include "newlib.h"
-#if ((__NEWLIB__ == 2) && (__NEWLIB_MINOR__ < 5)) ||((__NEWLIB__ == 3) && (__NEWLIB_MINOR__ > 1))
-  #warning "This wrapper was verified for newlib versions 2.5 - 3.1; please ensure newlib's external requirements for malloc-family are unchanged!"
+#if ((__NEWLIB__ == 2) && (__NEWLIB_MINOR__ < 5)) || ((__NEWLIB__ == 4) && (__NEWLIB_MINOR__ > 2) || (__NEWLIB__ < 2) || (__NEWLIB__ > 4))
+  #warning "This wrapper was verified for newlib versions 2.5 - 4.2; please ensure newlib's external requirements for malloc-family are unchanged!"
 #endif
 
 #include "FreeRTOS.h" // defines public interface we're implementing here

--- a/heap_useNewlib_ST.c
+++ b/heap_useNewlib_ST.c
@@ -73,8 +73,8 @@
 #include <stddef.h>
 
 #include "newlib.h"
-#if ((__NEWLIB__ == 2) && (__NEWLIB_MINOR__ < 5)) ||((__NEWLIB__ == 3) && (__NEWLIB_MINOR__ > 1))
-  #warning "This wrapper was verified for newlib versions 2.5 - 3.1; please ensure newlib's external requirements for malloc-family are unchanged!"
+#if ((__NEWLIB__ == 2) && (__NEWLIB_MINOR__ < 5)) || ((__NEWLIB__ == 4) && (__NEWLIB_MINOR__ > 2) || (__NEWLIB__ < 2) || (__NEWLIB__ > 4))
+  #warning "This wrapper was verified for newlib versions 2.5 - 4.2; please ensure newlib's external requirements for malloc-family are unchanged!"
 #endif
 
 #include "FreeRTOS.h" // defines public interface we're implementing here


### PR DESCRIPTION
Version test is now extended to the range 2.5 - 4.2

Compatibility is verified for newer newlib 4.1 and 4.2

New conditions are added to ensure the version is not lower than 2 or higher than 4. The previous version test was happy with newlib version 4 and no warning was generated.