### PR TITLE
Fix warning: ISO C does not allow extra ';' outside of a function

### DIFF
--- a/heap_useNewlib_NXP.c
+++ b/heap_useNewlib_NXP.c
@@ -150,7 +150,7 @@ void * _sbrk_r(struct _reent *pReent, int incr) {
         }
         #elif defined(configHARD_STOP_ON_MALLOC_FAILURE)
             // If you want to alert debugger or halt...
-            while(1) { __asm("bkpt #0"); }; // Stop in GUI as if at a breakpoint (if debugging, otherwise loop forever)
+            while(1) { __asm("bkpt #0"); } // Stop in GUI as if at a breakpoint (if debugging, otherwise loop forever)
         #else
             // Default, if you prefer to believe your application will gracefully trap out-of-memory...
             pReent->_errno = ENOMEM; // newlib's thread-specific errno
@@ -172,19 +172,19 @@ void * _sbrk_r(struct _reent *pReent, int incr) {
 // ... because the current _reent structure is pointed to by global _impure_ptr
 char * sbrk(int incr) { return _sbrk_r(_impure_ptr, incr); }
 //! _sbrk is a synonym for sbrk.
-char * _sbrk(int incr) { return sbrk(incr); };
+char * _sbrk(int incr) { return sbrk(incr); }
 
 void __malloc_lock(struct _reent *p)   { configASSERT( !xPortIsInsideInterrupt() ); // Make damn sure no mallocs inside ISRs!!
-                                               vTaskSuspendAll(); };
-void __malloc_unlock(struct _reent *p) { (void)xTaskResumeAll();  };
+                                               vTaskSuspendAll(); }
+void __malloc_unlock(struct _reent *p) { (void)xTaskResumeAll();  }
 
 // newlib also requires implementing locks for the application's environment memory space,
 // accessed by newlib's setenv() and getenv() functions.
 // As these are trivial functions, momentarily suspend task switching (rather than semaphore).
 // Not required (and trimmed by linker) in applications not using environment variables.
 // ToDo: Move __env_lock/unlock to a separate newlib helper file.
-void __env_lock()    {       vTaskSuspendAll(); };
-void __env_unlock()  { (void)xTaskResumeAll();  };
+void __env_lock()    {       vTaskSuspendAll(); }
+void __env_unlock()  { (void)xTaskResumeAll();  }
 
 #if 1 // Provide malloc debug and accounting wrappers
   /// /brief  Wrap malloc/malloc_r to help debug who requests memory and why.
@@ -201,16 +201,16 @@ void __env_unlock()  { (void)xTaskResumeAll();  };
       void *p = __real_malloc(nbytes); // will call malloc_r...
     inside_malloc = false;
     return p;
-  };
+  }
   void *__wrap__malloc_r(void *reent, size_t nbytes) {
     extern void * __real__malloc_r(size_t nbytes);
     if(!inside_malloc) {
       MallocCallCnt++;
       TotalMallocdBytes += nbytes;
-    };
+    }
     void *p = __real__malloc_r(nbytes);
     return p;
-  };
+  }
 #endif
 
 // ================================================================================================
@@ -223,7 +223,7 @@ void *pvPortMalloc( size_t xSize ) PRIVILEGED_FUNCTION {
 }
 void vPortFree( void *pv ) PRIVILEGED_FUNCTION {
     free(pv);
-};
+}
 
 size_t xPortGetFreeHeapSize( void ) PRIVILEGED_FUNCTION {
     struct mallinfo mi = mallinfo(); // available space now managed by newlib
@@ -234,4 +234,4 @@ size_t xPortGetFreeHeapSize( void ) PRIVILEGED_FUNCTION {
 // So, no implementation is provided: size_t xPortGetMinimumEverFreeHeapSize( void ) PRIVILEGED_FUNCTION;
 
 //! No implementation needed, but stub provided in case application already calls vPortInitialiseBlocks
-void vPortInitialiseBlocks( void ) PRIVILEGED_FUNCTION {};
+void vPortInitialiseBlocks( void ) PRIVILEGED_FUNCTION {}

--- a/heap_useNewlib_ST.c
+++ b/heap_useNewlib_ST.c
@@ -164,7 +164,7 @@ void * _sbrk_r(struct _reent *pReent, int incr) {
     #ifdef STM_VERSION // Use STM CubeMX LD symbols for heap
       if(TotalHeapSize==0) {
         TotalHeapSize = heapBytesRemaining = (int)((&__HeapLimit)-(&__HeapBase))-ISR_STACK_LENGTH_BYTES;
-      };
+      }
     #endif
     char* limit = (xTaskGetSchedulerState()==taskSCHEDULER_NOT_STARTED) ?
             stack_ptr   :  // Before scheduler is started, limit is stack pointer (risky!)
@@ -181,7 +181,7 @@ void * _sbrk_r(struct _reent *pReent, int incr) {
         #elif defined(configHARD_STOP_ON_MALLOC_FAILURE)
             // If you want to alert debugger or halt...
             // WARNING: brkpt instruction may prevent watchdog operation...
-            while(1) { __asm("bkpt #0"); }; // Stop in GUI as if at a breakpoint (if debugging, otherwise loop forever)
+            while(1) { __asm("bkpt #0"); } // Stop in GUI as if at a breakpoint (if debugging, otherwise loop forever)
         #else
             // Default, if you prefer to believe your application will gracefully trap out-of-memory...
             pReent->_errno = ENOMEM; // newlib's thread-specific errno
@@ -203,7 +203,7 @@ void * _sbrk_r(struct _reent *pReent, int incr) {
 // ... because the current _reent structure is pointed to by global _impure_ptr
 char * sbrk(int incr) { return _sbrk_r(_impure_ptr, incr); }
 //! _sbrk is a synonym for sbrk.
-char * _sbrk(int incr) { return sbrk(incr); };
+char * _sbrk(int incr) { return sbrk(incr); }
 
 #ifdef MALLOCS_INSIDE_ISRs // block interrupts during free-storage use
   static UBaseType_t malLock_uxSavedInterruptStatus;
@@ -217,7 +217,7 @@ void __malloc_lock(struct _reent *r)   {
     configASSERT( !insideAnISR ); // Make damn sure no more mallocs inside ISRs!!
   vTaskSuspendAll();
   #endif
-};
+}
 void __malloc_unlock(struct _reent *r) {
   (void)(r);
   #if defined(MALLOCS_INSIDE_ISRs)
@@ -225,15 +225,15 @@ void __malloc_unlock(struct _reent *r) {
   #else
   (void)xTaskResumeAll();
   #endif
-};
+}
 
 // newlib also requires implementing locks for the application's environment memory space,
 // accessed by newlib's setenv() and getenv() functions.
 // As these are trivial functions, momentarily suspend task switching (rather than semaphore).
 // Not required (and trimmed by linker) in applications not using environment variables.
 // ToDo: Move __env_lock/unlock to a separate newlib helper file.
-void __env_lock()    {       vTaskSuspendAll(); };
-void __env_unlock()  { (void)xTaskResumeAll();  };
+void __env_lock()    {       vTaskSuspendAll(); }
+void __env_unlock()  { (void)xTaskResumeAll();  }
 
 #if 1 // Provide malloc debug and accounting wrappers
   /// /brief  Wrap malloc/malloc_r to help debug who requests memory and why.
@@ -250,17 +250,17 @@ void __env_unlock()  { (void)xTaskResumeAll();  };
       void *p = __real_malloc(nbytes); // will call malloc_r...
     inside_malloc = false;
     return p;
-  };
+  }
   void *__wrap__malloc_r(void *reent, size_t nbytes) {
     (void)(reent);
     extern void * __real__malloc_r(size_t nbytes);
     if(!inside_malloc) {
       MallocCallCnt++;
       TotalMallocdBytes += nbytes;
-    };
+    }
     void *p = __real__malloc_r(nbytes);
     return p;
-  };
+  }
 #endif
 
 // ================================================================================================
@@ -273,7 +273,7 @@ void *pvPortMalloc( size_t xSize ) PRIVILEGED_FUNCTION {
 }
 void vPortFree( void *pv ) PRIVILEGED_FUNCTION {
     free(pv);
-};
+}
 
 size_t xPortGetFreeHeapSize( void ) PRIVILEGED_FUNCTION {
     struct mallinfo mi = mallinfo(); // available space now managed by newlib
@@ -284,4 +284,4 @@ size_t xPortGetFreeHeapSize( void ) PRIVILEGED_FUNCTION {
 // So, no implementation is provided: size_t xPortGetMinimumEverFreeHeapSize( void ) PRIVILEGED_FUNCTION;
 
 //! No implementation needed, but stub provided in case application already calls vPortInitialiseBlocks
-void vPortInitialiseBlocks( void ) PRIVILEGED_FUNCTION {};
+void vPortInitialiseBlocks( void ) PRIVILEGED_FUNCTION {}


### PR DESCRIPTION
It is not a real problem in many compilers but as you stated in #1 

> extraneous semi-colons - bad habit, please submit a pull request.

So here it is.