### PR TITLE
Optimize _sbrk_r when no increment is needed

### DIFF
--- a/heap_useNewlib_ST.c
+++ b/heap_useNewlib_ST.c
@@ -169,6 +169,11 @@ void * _sbrk_r(struct _reent *pReent, int incr) {
     char* limit = (xTaskGetSchedulerState()==taskSCHEDULER_NOT_STARTED) ?
             stack_ptr   :  // Before scheduler is started, limit is stack pointer (risky!)
             &__HeapLimit-ISR_STACK_LENGTH_BYTES;  // Once running, OK to reuse all remaining RAM except ISR stack (MSP) stack
+    char *previousHeapEnd = currentHeapEnd;
+    if(0 == incr) {
+        // don't go into a critical section if nothing has to change
+        return (char *) previousHeapEnd;
+    }
     DRN_ENTER_CRITICAL_SECTION(usis);
     if (currentHeapEnd + incr > limit) {
         // Ooops, no more memory available...
@@ -190,7 +195,6 @@ void * _sbrk_r(struct _reent *pReent, int incr) {
         return (char *)-1; // the malloc-family routine that called sbrk will return 0
     }
     // 'incr' of memory is available: update accounting and return it.
-    char *previousHeapEnd = currentHeapEnd;
     currentHeapEnd += incr;
     heapBytesRemaining -= incr;
     #ifndef NDEBUG


### PR DESCRIPTION
During debug I hit the _sbrk_r() function, but the incr parameter was 0. Callstack points out it is mallinfo() that initiates the call.
Because the current code goes into a critical section (ST) or suspends all tasks (NXP) but doesn't change anything in between, this is optimized away.

Unless the _sbrk_r is also used do some limit checks, I think this adjustment is safe.
Tested with an ST setup.
